### PR TITLE
Client 2 monospace digit error fix

### DIFF
--- a/Battleship.py
+++ b/Battleship.py
@@ -6,7 +6,7 @@ enemyGameBoard = [0] * 100 # Used to determine whether your moves hit or missed,
 enemyBoatLog = [2, 3, 3, 4, 5] 
 personalBoatLog = [2, 3, 3, 4, 5]
 
-monospace_digit_three = "\U0001D7F9" # Alternate 3 
+monospace_digit_three = "C" # Alternate 3 for the second cruiser
 
 sampleBoardString = "555550000044440000003330000000" + monospace_digit_three + monospace_digit_three + monospace_digit_three + "0000000220000000000000000000000000000000000000000000000000000000000"
 

--- a/server.py
+++ b/server.py
@@ -51,7 +51,7 @@ def player_turn(player: socket.socket):
             target = bs.enemyGameBoard[move_ind]
             if target != '0' and target != 'X':
                 bs.updatePersonalBoatLog(target, bs.enemyBoatLog)
-                enemyGameBoard[move_ind] = 'X'
+                bs.enemyGameBoard[move_ind] = 'X'
                 message_send(player, f"{MSG_OUTCOME} hit")
             else: message_send(player, f"{MSG_OUTCOME} miss")
         else:
@@ -87,7 +87,7 @@ def get_player_empty_board(sock: socket.socket):
         client_sock, client_addr, m = get_player(sock)
         if (client_sock is None or client_addr is None or m is None):
             return None, None, None
-        board_received = m[len(MSG_JOIN)+1:]
+        board_received = list(m[len(MSG_JOIN)+1:]) 
         print(board_received)
         accept_connection(client_sock)
         return client_sock, client_addr, board_received


### PR DESCRIPTION
Should fix the second client joining issue that was caused by networking issues using this protocol expecting fixed byte length characters interacting strangely with Unicode characters. The mono space digit is replaced by an ascii C for cruiser. During testing a couple of errors in the server's implementation came up due to having a complete client/board to test with, which have also been addressed.